### PR TITLE
feat(editor): wire sidebar customization, consolidate action bar

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -333,6 +333,18 @@
   fill: #7b5d00;
 }
 
+.hazardStripeYellow {
+  fill: #fbbf24;
+}
+
+.dark .hazardStripeYellow {
+  fill: #0440db;
+}
+
+.hazardStripeDark {
+  fill: #000000;
+}
+
 .rocketPorthole {
   transition: fill 0.32s cubic-bezier(0.165, 0.84, 0.44, 1);
 }

--- a/components/editor/EditorShell.tsx
+++ b/components/editor/EditorShell.tsx
@@ -147,6 +147,7 @@ export function EditorShell({ assets }: EditorShellProps) {
           state={state}
           onGlobalStateChange={handleChange}
           resetDocumentRef={resetDocumentRef}
+          onFullReset={handleFullReset}
           onPathCountChange={setSelectedPathCount}
         />
 

--- a/components/editor/EditorWorkspaceSection.tsx
+++ b/components/editor/EditorWorkspaceSection.tsx
@@ -12,6 +12,7 @@ interface EditorWorkspaceSectionProps {
   state: CustomizationState;
   onGlobalStateChange: (updates: Partial<CustomizationState>) => void;
   resetDocumentRef: MutableRefObject<() => void>;
+  onFullReset: () => void;
   onPathCountChange?: (count: number) => void;
 }
 
@@ -20,6 +21,7 @@ export function EditorWorkspaceSection({
   state,
   onGlobalStateChange,
   resetDocumentRef,
+  onFullReset,
   onPathCountChange,
 }: EditorWorkspaceSectionProps) {
   const doc = useEditorDocument(assets);
@@ -54,7 +56,7 @@ export function EditorWorkspaceSection({
       onSelectPath={doc.setSelectedPathId}
       onCommitPathDraft={doc.commitPathDraft}
       isModified={doc.isModified}
-      onResetAsset={doc.resetCurrentAsset}
+      onResetAsset={onFullReset}
       onUndo={doc.handleUndo}
       onRedo={doc.handleRedo}
       canUndo={doc.canUndo}

--- a/components/editor/canvas/EditorCanvasStage.tsx
+++ b/components/editor/canvas/EditorCanvasStage.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { memo, type ReactNode } from "react";
+import type { CustomizationState } from "@/lib/types";
+import { useCanvasStyles } from "@/hooks/use-canvas-styles";
+import { cn } from "@/lib/utils";
+
+interface EditorCanvasStageProps {
+  state: CustomizationState;
+  children: ReactNode;
+  className?: string;
+  applyContainerBox?: boolean;
+}
+
+export const EditorCanvasStage = memo(function EditorCanvasStage({
+  state,
+  children,
+  className,
+  applyContainerBox = true,
+}: EditorCanvasStageProps) {
+  const { transform, boxShadow, blurFilter, noiseFilter } =
+    useCanvasStyles(state);
+
+  const innerFilter =
+    [
+      state.shadow.inner ? "url(#inner-shadow)" : null,
+      blurFilter || null,
+      noiseFilter || null,
+      state.texture.enabled && state.texture.selected !== "none"
+        ? "url(#texture-filter)"
+        : null,
+    ]
+      .filter(Boolean)
+      .join(" ") || undefined;
+
+  const containerStyle: React.CSSProperties = {
+    overflow: "hidden",
+    borderRadius: state.cornerRadius,
+    ...(applyContainerBox
+      ? {
+          padding: state.padding,
+          background: state.backgroundColor || "transparent",
+          boxShadow:
+            state.shadow.enabled && state.shadow.inner ? "none" : boxShadow,
+        }
+      : null),
+  };
+
+  return (
+    <div
+      className={cn("flex h-full w-full items-center justify-center", className)}
+      style={containerStyle}
+    >
+      <div
+        className="flex h-full w-full items-center justify-center"
+        style={{
+          transform,
+          transformOrigin: "center center",
+          filter: innerFilter,
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+});

--- a/components/editor/canvas/EditorDrawCanvas.tsx
+++ b/components/editor/canvas/EditorDrawCanvas.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useRef, useState } from "react";
 import type { EditorDocument } from "@/lib/editor/types";
 import type { CustomizationState } from "@/lib/types";
-import { resolveEditorPathPaint } from "@/lib/editor/svg";
+import { resolveEditorPathStyle } from "@/lib/editor/svg";
 import {
   simplifyPoints,
   pointsToSmoothPath,
@@ -256,7 +256,7 @@ export function EditorDrawCanvas({
                 return true;
               })
               .map((p) => {
-                const paint = resolveEditorPathPaint(p, state);
+                const style = resolveEditorPathStyle(p, state);
                 const isErasable = isEraserTool && !!onErasePath;
                 const isReference = referencePathIds.has(p.id);
                 const renderedOpacity = isReference
@@ -267,11 +267,11 @@ export function EditorDrawCanvas({
                   <path
                     key={p.id}
                     d={p.d}
-                    fill={paint.fill}
-                    stroke={paint.stroke}
-                    strokeWidth={p.strokeWidth ?? 1.5}
-                    strokeLinecap={p.strokeLinecap ?? "round"}
-                    strokeLinejoin={p.strokeLinejoin ?? "round"}
+                    fill={style.fill}
+                    stroke={style.stroke}
+                    strokeWidth={style.strokeWidth}
+                    strokeLinecap={style.strokeLinecap}
+                    strokeLinejoin={style.strokeLinejoin}
                     opacity={renderedOpacity}
                     pointerEvents={isErasable ? "all" : "none"}
                     style={isErasable ? { cursor: "crosshair" } : undefined}

--- a/components/editor/canvas/EditorPathCanvas.tsx
+++ b/components/editor/canvas/EditorPathCanvas.tsx
@@ -10,7 +10,7 @@ import {
   type ControlPoint,
 } from "@/components/editor/utils/svg-path-utils";
 import { ensureEditorPathEditable } from "@/lib/editor/path-data";
-import { resolveEditorPathPaint } from "@/lib/editor/svg";
+import { resolveEditorPathStyle } from "@/lib/editor/svg";
 
 interface EditorPathCanvasProps {
   state: CustomizationState;
@@ -260,9 +260,52 @@ export function EditorPathCanvas({
   };
 
   if (!path) {
+    const visiblePaths = (allPaths ?? []).filter((p) => p.visible);
+    if (visiblePaths.length === 0) {
+      return (
+        <div className="h-full flex items-center justify-center text-sm text-muted-foreground">
+          Click a path on the canvas to edit it.
+        </div>
+      );
+    }
     return (
-      <div className="h-full flex items-center justify-center text-sm text-muted-foreground">
-        Click a path on the canvas to edit it.
+      <div className="relative h-full w-full">
+        <div className="absolute inset-0">
+          <svg
+            viewBox={paddedViewBox}
+            className="relative z-10 h-full w-full"
+            preserveAspectRatio="xMidYMid meet"
+            style={{ touchAction: "none", overflow: "hidden" }}
+          >
+            <g>
+              {visiblePaths.map((bp) => {
+                const style = resolveEditorPathStyle(bp, state);
+                return (
+                  <path
+                    key={bp.id}
+                    d={bp.d}
+                    fill={style.fill}
+                    stroke={style.stroke}
+                    strokeWidth={style.strokeWidth}
+                    strokeLinecap={style.strokeLinecap}
+                    strokeLinejoin={style.strokeLinejoin}
+                    fillRule={bp.fillRule}
+                    clipRule={bp.clipRule}
+                    style={{ cursor: onSelectPath ? "pointer" : undefined }}
+                    onClick={
+                      onSelectPath
+                        ? (e) => {
+                            e.stopPropagation();
+                            onSelectPath(bp.id);
+                          }
+                        : undefined
+                    }
+                  />
+                );
+              })}
+            </g>
+          </svg>
+        </div>
       </div>
     );
   }
@@ -288,17 +331,17 @@ export function EditorPathCanvas({
           >
             <g>
               {backgroundPaths.map((bp) => {
-                const paint = resolveEditorPathPaint(bp, state);
+                const style = resolveEditorPathStyle(bp, state);
 
                 return (
                   <path
                     key={bp.id}
                     d={bp.d}
-                    fill={paint.fill}
-                    stroke={paint.stroke}
-                    strokeWidth={bp.strokeWidth ?? 1.5}
-                    strokeLinecap={bp.strokeLinecap ?? "round"}
-                    strokeLinejoin={bp.strokeLinejoin ?? "round"}
+                    fill={style.fill}
+                    stroke={style.stroke}
+                    strokeWidth={style.strokeWidth}
+                    strokeLinecap={style.strokeLinecap}
+                    strokeLinejoin={style.strokeLinejoin}
                     fillRule={bp.fillRule}
                     clipRule={bp.clipRule}
                     opacity={0.35}
@@ -316,16 +359,16 @@ export function EditorPathCanvas({
               })}
 
               {(() => {
-                const paint = resolveEditorPathPaint(path, state);
+                const style = resolveEditorPathStyle(path, state);
 
                 return (
                   <path
                     d={currentEditPath}
-                    fill={paint.fill}
-                    stroke={paint.stroke}
-                    strokeWidth={path.strokeWidth ?? 1.5}
-                    strokeLinecap={path.strokeLinecap ?? "round"}
-                    strokeLinejoin={path.strokeLinejoin ?? "round"}
+                    fill={style.fill}
+                    stroke={style.stroke}
+                    strokeWidth={style.strokeWidth}
+                    strokeLinecap={style.strokeLinecap}
+                    strokeLinejoin={style.strokeLinejoin}
                     fillRule={path.fillRule}
                     clipRule={path.clipRule}
                   />

--- a/components/editor/controls/EditorActionBar.tsx
+++ b/components/editor/controls/EditorActionBar.tsx
@@ -219,18 +219,20 @@ export function EditorActionBar({
   };
 
   const downloadSvg = async () => {
-    const svg = await getSvgContent();
-    if (!svg) return;
-    const blob = new Blob([svg], { type: "image/svg+xml" });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = "icon.svg";
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    setTimeout(() => URL.revokeObjectURL(url), 1000);
-    toast.success("SVG downloaded successfully");
+    await withPending(async () => {
+      const svg = await getSvgContent();
+      if (!svg) return;
+      const blob = new Blob([svg], { type: "image/svg+xml" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "icon.svg";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      setTimeout(() => URL.revokeObjectURL(url), 1000);
+      toast.success("SVG downloaded successfully");
+    });
   };
 
   const groupLayoutTransition = reduceMotion
@@ -533,12 +535,14 @@ export function EditorActionBar({
                 disabled={isPending}
                 className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-[11px] font-medium transition-colors focus:bg-white/10 focus:text-white"
                 onClick={async () => {
-                  const svg = await getSvgContent();
-                  if (svg) {
-                    copyToClipboard(svg, "SVG");
-                  } else {
-                    toast.error("Nothing to copy");
-                  }
+                  await withPending(async () => {
+                    const svg = await getSvgContent();
+                    if (svg) {
+                      await copyToClipboard(svg, "SVG");
+                    } else {
+                      toast.error("Nothing to copy");
+                    }
+                  });
                 }}
               >
                 <FileCode className="h-4 w-4 text-white/40" />

--- a/components/editor/controls/EditorActionBar.tsx
+++ b/components/editor/controls/EditorActionBar.tsx
@@ -1,0 +1,572 @@
+"use client";
+
+import { useCallback, useRef, useState, type ReactNode } from "react";
+import {
+  Check,
+  ChevronDown,
+  Download,
+  Eye,
+  EyeOff,
+  FileCode,
+  Grid3X3,
+  Redo,
+  RotateCcw,
+  Undo,
+  X,
+} from "lucide-react";
+import {
+  AnimatePresence,
+  LayoutGroup,
+  motion,
+  useReducedMotion,
+} from "motion/react";
+import { toast } from "sonner";
+
+export const EDITOR_TRANSITION = {
+  pill: 0.22,
+  pillExit: 0.18,
+  pillLayout: {
+    type: "spring" as const,
+    duration: 0.28,
+    bounce: 0.12,
+  },
+  toolStagger: 0.025,
+  toolStaggerExit: 0.015,
+  toolFade: 0.16,
+  toolFadeExit: 0.12,
+  toolDelay: 0.12,
+  toggle: 0.22,
+  canvas: 0.3,
+  canvasExit: 0.24,
+  canvasFade: 0.16,
+  canvasFadeExit: 0.08,
+  tray: 0.16,
+  trayDelay: 0.24,
+  easeOut: [0.215, 0.61, 0.355, 1] as [number, number, number, number],
+  easeInOut: [0.645, 0.045, 0.355, 1] as [number, number, number, number],
+} as const;
+
+const toolsParent = {
+  hidden: {
+    transition: {
+      staggerChildren: EDITOR_TRANSITION.toolStaggerExit,
+      staggerDirection: -1,
+    },
+  },
+  visible: {
+    transition: {
+      delayChildren: EDITOR_TRANSITION.toolDelay,
+      staggerChildren: EDITOR_TRANSITION.toolStagger,
+    },
+  },
+};
+
+const toolChild = {
+  hidden: {
+    opacity: 0,
+    scale: 0.7,
+    transition: {
+      duration: EDITOR_TRANSITION.toolFadeExit,
+      ease: EDITOR_TRANSITION.easeOut,
+    },
+  },
+  visible: {
+    opacity: 1,
+    scale: 1,
+    transition: {
+      duration: EDITOR_TRANSITION.toolFade,
+      ease: EDITOR_TRANSITION.easeOut,
+    },
+  },
+};
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  DRAW_TOOLS,
+  type DrawTool,
+} from "@/components/editor/controls/EditorDrawToolbar";
+import type { CustomizationState } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+export interface EditorActionBarProps {
+  state?: CustomizationState;
+  onChange?: (updates: Partial<CustomizationState>) => void;
+  onUndo?: () => void;
+  onRedo?: () => void;
+  canUndo?: boolean;
+  canRedo?: boolean;
+  onReset?: () => void;
+  showGrid?: boolean;
+  onGridToggle?: () => void;
+  onGetSvgContent?: () => Promise<string>;
+  editorMode: "edit" | "draw";
+  activeTool: DrawTool;
+  onToolChange: (tool: DrawTool) => void;
+  showReference: boolean;
+  onToggleReference: () => void;
+  additionalDropdownItems?: ReactNode;
+  className?: string;
+}
+
+export function EditorActionBar({
+  state,
+  onChange,
+  onUndo,
+  onRedo,
+  canUndo = false,
+  canRedo = false,
+  onReset,
+  showGrid = false,
+  onGridToggle,
+  onGetSvgContent,
+  editorMode,
+  activeTool,
+  onToolChange,
+  showReference,
+  onToggleReference,
+  additionalDropdownItems,
+  className,
+}: EditorActionBarProps) {
+  const reduceMotion = useReducedMotion();
+  const [isPending, setIsPending] = useState(false);
+  const withPending = async (fn: () => Promise<void>) => {
+    if (isPending) return;
+    setIsPending(true);
+    try {
+      await fn();
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  const [isResetArmed, setIsResetArmed] = useState(false);
+  const [timeLeft, setTimeLeft] = useState(5);
+  const [resetTooltipOpen, setResetTooltipOpen] = useState(false);
+  const resetTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const countdownIntervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  const disarmReset = useCallback(() => {
+    setIsResetArmed(false);
+    setTimeLeft(5);
+    if (resetTimeoutRef.current) {
+      clearTimeout(resetTimeoutRef.current);
+      resetTimeoutRef.current = null;
+    }
+    if (countdownIntervalRef.current) {
+      clearInterval(countdownIntervalRef.current);
+      countdownIntervalRef.current = null;
+    }
+  }, []);
+
+  const armReset = useCallback(() => {
+    setIsResetArmed(true);
+    setTimeLeft(5);
+    countdownIntervalRef.current = setInterval(() => {
+      setTimeLeft((prev) => {
+        if (prev <= 1) {
+          disarmReset();
+          return 5;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+    resetTimeoutRef.current = setTimeout(() => {
+      disarmReset();
+    }, 5000);
+  }, [disarmReset]);
+
+  const handleResetClick = useCallback(() => {
+    if (!isResetArmed) {
+      armReset();
+    }
+  }, [isResetArmed, armReset]);
+
+  const handleConfirmReset = useCallback(() => {
+    disarmReset();
+    onReset?.();
+    toast.success("Customizations reset");
+  }, [disarmReset, onReset]);
+
+  const copyToClipboard = async (text: string, label: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      toast.success(`${label} copied to clipboard`);
+    } catch {
+      toast.error("Failed to copy to clipboard");
+    }
+  };
+
+  const getSvgContent = async (): Promise<string> => {
+    if (!onGetSvgContent) return "";
+    try {
+      return await onGetSvgContent();
+    } catch (error) {
+      console.error("Custom SVG generator failed:", error);
+      toast.error("Export failed.");
+      return "";
+    }
+  };
+
+  const downloadSvg = async () => {
+    const svg = await getSvgContent();
+    if (!svg) return;
+    const blob = new Blob([svg], { type: "image/svg+xml" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "icon.svg";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+    toast.success("SVG downloaded successfully");
+  };
+
+  const groupLayoutTransition = reduceMotion
+    ? { duration: 0 }
+    : EDITOR_TRANSITION.pillLayout;
+
+  return (
+    <TooltipProvider delayDuration={400}>
+      <LayoutGroup>
+        <div
+          className={cn(
+            "flex h-[46px] items-stretch gap-1.5 rounded-[14px] p-1 border border-black/5 dark:border-white/10 shadow-[inset_0_2px_4px_rgba(0,0,0,0.15)]",
+            "bg-[#f5f5f5] dark:bg-[#1a1a1a]",
+            className,
+          )}
+        >
+        <motion.div
+          layout
+          transition={groupLayoutTransition}
+          className="flex items-center gap-1 rounded-[10px] bg-[#1d1d1f] p-[3px] shadow-[inset_0_1px_1px_rgba(0,0,0,0.4),0_0_0_1px_rgba(0,0,0,0.5)]"
+        >
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={onUndo}
+                disabled={!canUndo}
+                className="flex h-9 w-9 items-center justify-center rounded-[7px] text-[#c9c9cb] transition-all hover:bg-white/5 hover:text-white active:translate-y-[0.5px] disabled:cursor-not-allowed disabled:text-[#4f4f51]"
+              >
+                <Undo className="h-3.5 w-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              <p>
+                Undo <span className="ml-1 opacity-50 text-[10px]">⌘Z</span>
+              </p>
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={onRedo}
+                disabled={!canRedo}
+                className="flex h-9 w-9 items-center justify-center rounded-[7px] text-[#c9c9cb] transition-all hover:bg-white/5 hover:text-white active:translate-y-[0.5px] disabled:cursor-not-allowed disabled:text-[#4f4f51]"
+              >
+                <Redo className="h-3.5 w-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              <p>
+                Redo <span className="ml-1 opacity-50 text-[10px]">⌘Y</span>
+              </p>
+            </TooltipContent>
+          </Tooltip>
+          <div className="relative">
+            <Tooltip
+              open={!isResetArmed && resetTooltipOpen}
+              onOpenChange={setResetTooltipOpen}
+            >
+              <TooltipTrigger asChild>
+                <button
+                  onClick={handleResetClick}
+                  className={cn(
+                    "flex h-9 w-9 items-center justify-center rounded-[7px] transition-all active:translate-y-[0.5px]",
+                    isResetArmed
+                      ? "bg-white text-black"
+                      : "text-[#c9c9cb] hover:bg-white/5 hover:text-white",
+                  )}
+                >
+                  <RotateCcw className="h-3.5 w-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                <p>Reset</p>
+              </TooltipContent>
+            </Tooltip>
+            <AnimatePresence>
+              {isResetArmed && (
+                <motion.div
+                  initial={{ opacity: 0, y: 0, scale: 0.95 }}
+                  animate={{ opacity: 1, y: -80, scale: 1 }}
+                  exit={{ opacity: 0, y: 0, scale: 0.95 }}
+                  className="absolute left-1/2 -translate-x-1/2 flex items-center gap-1 rounded-[9px] bg-[#2c2c2e] p-1 shadow-[0_20px_50px_rgba(0,0,0,0.5),0_0_0_1px_rgba(255,255,255,0.1)] z-[100] whitespace-nowrap"
+                >
+                  <button
+                    onClick={handleConfirmReset}
+                    className="flex h-7 px-3 items-center gap-2 rounded-[6px] bg-white text-black hover:bg-white/90 transition-all font-bold text-[10px] shadow-sm"
+                  >
+                    <Check className="h-3.5 w-3.5" />
+                    <span>Reset</span>
+                    <span className="font-mono text-[9px] tabular-nums text-[#10b981] font-bold">
+                      {timeLeft}s
+                    </span>
+                  </button>
+                  <button
+                    onClick={disarmReset}
+                    className="flex h-7 w-7 items-center justify-center rounded-[6px] text-white/50 hover:bg-white/5 hover:text-white transition-all"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                  <div className="absolute -bottom-1 left-1/2 -translate-x-1/2 w-2 h-2 bg-[#2c2c2e] border-r border-b border-white/10 rotate-45 z-[-1]" />
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        </motion.div>
+
+        <motion.div
+          layout
+          transition={groupLayoutTransition}
+          className="flex items-center rounded-[10px] bg-[#1d1d1f] p-[3px] shadow-[inset_0_1px_1px_rgba(0,0,0,0.4),0_0_0_1px_rgba(0,0,0,0.5)]"
+        >
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button className="group flex h-full min-w-[64px] items-center justify-center gap-1.5 rounded-[7px] px-2 text-[#c9c9cb] transition-all hover:bg-white/5 hover:text-white focus:outline-none">
+                <span className="font-mono text-[11px] font-bold tracking-tighter">
+                  {state?.width}px
+                </span>
+                <ChevronDown className="h-4 w-4 opacity-50 transition-opacity group-hover:opacity-100" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="center"
+              className="w-[85px] border-white/10 bg-[#2c2c2e] p-1 text-white shadow-xl"
+            >
+              {[16, 20, 24, 28, 32, 48, 64, 96, 128].map((size) => (
+                <DropdownMenuItem
+                  key={size}
+                  className="flex cursor-pointer items-center justify-between rounded-md px-2 py-1 text-[11px] font-medium transition-colors focus:bg-white/10 focus:text-white"
+                  onClick={() => onChange?.({ width: size, height: size })}
+                >
+                  <span>{size}px</span>
+                  {state?.width === size && (
+                    <Check className="h-2.5 w-2.5 text-white/50" />
+                  )}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={onGridToggle}
+                className={cn(
+                  "flex h-full w-9 items-center justify-center rounded-[7px] transition-all active:translate-y-[0.5px]",
+                  showGrid
+                    ? "bg-[#1d1d1f] text-white shadow-[inset_0_0_0_1.5px_rgba(255,255,255,0.95),0_1px_2px_rgba(0,0,0,0.4)]"
+                    : "text-[#c9c9cb] hover:bg-white/5 hover:text-white",
+                )}
+              >
+                <Grid3X3 className="h-3.5 w-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              <p>{showGrid ? "Hide Grid" : "Show Grid"}</p>
+            </TooltipContent>
+          </Tooltip>
+        </motion.div>
+
+        <AnimatePresence initial={false} mode="popLayout">
+          {editorMode === "draw" && (
+            <motion.div
+              key="draw-tools"
+              layout
+              initial={
+                reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.92 }
+              }
+              animate={
+                reduceMotion ? { opacity: 1 } : { opacity: 1, scale: 1 }
+              }
+              exit={
+                reduceMotion
+                  ? { opacity: 0 }
+                  : {
+                      opacity: 0,
+                      scale: 0.92,
+                      transition: {
+                        duration: EDITOR_TRANSITION.pillExit,
+                        ease: EDITOR_TRANSITION.easeOut,
+                      },
+                    }
+              }
+              transition={
+                reduceMotion
+                  ? { duration: 0 }
+                  : {
+                      layout: EDITOR_TRANSITION.pillLayout,
+                      opacity: {
+                        duration: EDITOR_TRANSITION.pill,
+                        ease: EDITOR_TRANSITION.easeOut,
+                      },
+                      scale: {
+                        duration: EDITOR_TRANSITION.pill,
+                        ease: EDITOR_TRANSITION.easeOut,
+                      },
+                    }
+              }
+              style={{ originX: 0.5, originY: 0.5 }}
+              className="flex items-center gap-0.5 rounded-[10px] bg-[#1d1d1f] p-[3px] shadow-[inset_0_1px_1px_rgba(0,0,0,0.4),0_0_0_1px_rgba(0,0,0,0.5)]"
+            >
+              <motion.div
+                variants={reduceMotion ? undefined : toolsParent}
+                initial="hidden"
+                animate="visible"
+                exit="hidden"
+                className="flex items-center gap-0.5"
+              >
+                {DRAW_TOOLS.map(({ id, label, Icon }) => {
+                  const isActive = activeTool === id;
+                  return (
+                    <Tooltip key={id}>
+                      <TooltipTrigger asChild>
+                        <motion.button
+                          variants={reduceMotion ? undefined : toolChild}
+                          type="button"
+                          onClick={() => onToolChange(id)}
+                          aria-pressed={isActive}
+                          aria-label={label}
+                          className={cn(
+                            "flex h-9 w-9 items-center justify-center rounded-[7px] transition-all active:translate-y-[0.5px]",
+                            isActive
+                              ? "bg-white text-black"
+                              : "text-[#c9c9cb] hover:bg-white/5 hover:text-white",
+                          )}
+                        >
+                          <Icon className="h-3.5 w-3.5" />
+                        </motion.button>
+                      </TooltipTrigger>
+                      <TooltipContent side="top">
+                        <p>{label}</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  );
+                })}
+                <div
+                  className="mx-0.5 h-5 w-px bg-white/10"
+                  aria-hidden="true"
+                />
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <motion.button
+                      variants={reduceMotion ? undefined : toolChild}
+                      type="button"
+                      onClick={onToggleReference}
+                      aria-pressed={showReference}
+                      aria-label={
+                        showReference ? "Hide reference" : "Show reference"
+                      }
+                      className={cn(
+                        "flex h-9 w-9 items-center justify-center rounded-[7px] transition-all active:translate-y-[0.5px]",
+                        showReference
+                          ? "bg-white text-black"
+                          : "text-[#c9c9cb] hover:bg-white/5 hover:text-white",
+                      )}
+                    >
+                      {showReference ? (
+                        <Eye className="h-3.5 w-3.5" />
+                      ) : (
+                        <EyeOff className="h-3.5 w-3.5" />
+                      )}
+                    </motion.button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">
+                    <p>
+                      {showReference ? "Hide reference" : "Show reference"}
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              </motion.div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        <motion.div
+          layout
+          transition={groupLayoutTransition}
+          className="flex items-center rounded-[10px] bg-[#1d1d1f] p-[3px] shadow-[inset_0_1px_1px_rgba(0,0,0,0.4),0_0_0_1px_rgba(0,0,0,0.5)]"
+        >
+          <button
+            disabled={isPending}
+            onClick={downloadSvg}
+            className="group relative flex h-full flex-1 items-center justify-center gap-2 overflow-hidden rounded-[7px] bg-white px-4 text-center transition-all hover:bg-white/90 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-40 dark:bg-white dark:text-black"
+          >
+            <div className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-black/5 to-transparent transition-transform duration-500 ease-out group-hover:translate-x-full" />
+            <Download className="h-3.5 w-3.5" />
+            <span className="text-[10px] font-bold tracking-tight whitespace-nowrap">
+              {isPending ? "Exporting..." : "Export SVG"}
+            </span>
+          </button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button className="group flex h-full w-8 items-center justify-center rounded-[7px] bg-white text-black transition-all hover:bg-white/90 active:scale-[0.98] dark:bg-white dark:text-black">
+                <ChevronDown className="h-4 w-4 opacity-70 transition-opacity group-hover:opacity-100" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              className="w-[146px] border-white/10 bg-[#2c2c2e] p-1 text-white shadow-2xl"
+            >
+              <DropdownMenuItem
+                disabled={isPending}
+                className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-[11px] font-medium transition-colors focus:bg-white/10 focus:text-white"
+                onClick={async () => {
+                  const svg = await getSvgContent();
+                  if (svg) {
+                    copyToClipboard(svg, "SVG");
+                  } else {
+                    toast.error("Nothing to copy");
+                  }
+                }}
+              >
+                <FileCode className="h-4 w-4 text-white/40" />
+                <div className="flex flex-1 items-center justify-between">
+                  <span>Copy as SVG</span>
+                  <span className="font-mono text-[9px] opacity-40">SVG</span>
+                </div>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator className="my-0.5 bg-white/5" />
+              <DropdownMenuItem
+                disabled={isPending}
+                className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-[11px] font-medium transition-colors focus:bg-white/10 focus:text-white"
+                onClick={downloadSvg}
+              >
+                <Download className="h-4 w-4 text-white/40" />
+                <span>Download as SVG</span>
+              </DropdownMenuItem>
+              {additionalDropdownItems && (
+                <>
+                  <DropdownMenuSeparator className="my-0.5 bg-white/5" />
+                  {additionalDropdownItems}
+                </>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </motion.div>
+        </div>
+      </LayoutGroup>
+    </TooltipProvider>
+  );
+}

--- a/components/editor/controls/EditorDrawToolbar.tsx
+++ b/components/editor/controls/EditorDrawToolbar.tsx
@@ -28,7 +28,7 @@ interface EditorDrawToolbarProps {
   onToggleReference: () => void;
 }
 
-const TOOLS: { id: DrawTool; label: string; Icon: typeof Pencil }[] = [
+export const DRAW_TOOLS: { id: DrawTool; label: string; Icon: typeof Pencil }[] = [
   { id: "pen", label: "Pen", Icon: Pencil },
   { id: "rect", label: "Rectangle", Icon: Square },
   { id: "ellipse", label: "Ellipse", Icon: Circle },
@@ -36,6 +36,8 @@ const TOOLS: { id: DrawTool; label: string; Icon: typeof Pencil }[] = [
   { id: "bucket", label: "Bucket fill", Icon: PaintBucket },
   { id: "eraser", label: "Eraser", Icon: Eraser },
 ];
+
+const TOOLS = DRAW_TOOLS;
 
 export const EditorDrawToolbar = memo(function EditorDrawToolbar({
   activeTool,

--- a/components/editor/controls/EditorIconTray.tsx
+++ b/components/editor/controls/EditorIconTray.tsx
@@ -3,7 +3,7 @@
 import { memo } from "react";
 import * as m from "motion/react-m";
 import { AnimatePresence } from "motion/react";
-import { Plus, X } from "lucide-react";
+import { X } from "lucide-react";
 import type { EditorAssetSummary } from "@/lib/editor/types";
 import { cn } from "@/lib/utils";
 import { EditorSvgPreview } from "@/components/editor/preview/EditorSvgPreview";
@@ -30,7 +30,7 @@ export const EditorIconTray = memo(function EditorIconTray({
   onRemoveAsset,
   onCreateBlank,
 }: EditorIconTrayProps) {
-  const emptySlots = Math.max(0, 6 - assets.length - 1);
+  const emptySlots = Math.max(0, 6 - assets.length);
 
   return (
     <div className="relative z-10 grid grid-cols-6 w-full h-full">
@@ -87,26 +87,6 @@ export const EditorIconTray = memo(function EditorIconTray({
           );
         })}
       </AnimatePresence>
-
-      {assets.length < 6 ? (
-        <div className="flex items-center justify-center">
-          <button
-            type="button"
-            onClick={onCreateBlank}
-            disabled={!onCreateBlank}
-            aria-label="Create blank icon"
-            className={cn(
-              "w-11 h-11 rounded-lg border border-dashed flex items-center justify-center",
-              "transition-[colors,transform] duration-150 ease-out",
-              onCreateBlank
-                ? "border-border/40 text-muted-foreground/40 hover:border-border hover:text-foreground hover:bg-muted/20 hover:scale-105 active:scale-[0.97] cursor-pointer"
-                : "border-border/30 text-muted-foreground/20",
-            )}
-          >
-            <Plus className="w-4 h-4" />
-          </button>
-        </div>
-      ) : null}
 
       {Array.from({ length: emptySlots }).map((_, idx) => (
         <div key={`pad-${idx}`} />

--- a/components/editor/controls/EditorModeToggle.tsx
+++ b/components/editor/controls/EditorModeToggle.tsx
@@ -2,7 +2,9 @@
 
 import { memo } from "react";
 import { MousePointer, Pencil } from "lucide-react";
+import { LayoutGroup, motion, useReducedMotion } from "motion/react";
 import { cn } from "@/lib/utils";
+import { EDITOR_TRANSITION } from "@/components/editor/controls/EditorActionBar";
 
 type EditorMode = "edit" | "draw";
 
@@ -11,40 +13,60 @@ interface EditorModeToggleProps {
   onModeChange: (mode: EditorMode) => void;
 }
 
+const MODES: { id: EditorMode; label: string; Icon: typeof MousePointer }[] = [
+  { id: "edit", label: "Edit", Icon: MousePointer },
+  { id: "draw", label: "Draw", Icon: Pencil },
+];
+
 export const EditorModeToggle = memo(function EditorModeToggle({
   mode,
   onModeChange,
 }: EditorModeToggleProps) {
+  const reduceMotion = useReducedMotion();
+
   return (
-    <div>
+    <LayoutGroup>
       <div className="flex items-center gap-0.5 p-0.5 bg-background/90 backdrop-blur-xl border border-border rounded-lg shadow-sm">
-        <button
-          type="button"
-          onClick={() => onModeChange("edit")}
-          className={cn(
-            "flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors",
-            mode === "edit"
-              ? "bg-foreground text-background"
-              : "text-muted-foreground hover:text-foreground hover:bg-muted/50",
-          )}
-        >
-          <MousePointer className="h-3.5 w-3.5" />
-          Edit
-        </button>
-        <button
-          type="button"
-          onClick={() => onModeChange("draw")}
-          className={cn(
-            "flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors",
-            mode === "draw"
-              ? "bg-foreground text-background"
-              : "text-muted-foreground hover:text-foreground hover:bg-muted/50",
-          )}
-        >
-          <Pencil className="h-3.5 w-3.5" />
-          Draw
-        </button>
+        {MODES.map(({ id, label, Icon }) => {
+          const active = mode === id;
+          return (
+            <button
+              key={id}
+              type="button"
+              onClick={() => onModeChange(id)}
+              aria-pressed={active}
+              className="relative flex items-center rounded-md focus:outline-none"
+            >
+              {active && (
+                <motion.div
+                  layoutId="editor-mode-indicator"
+                  className="absolute inset-0 rounded-md bg-foreground"
+                  transition={
+                    reduceMotion
+                      ? { duration: 0 }
+                      : {
+                          type: "spring",
+                          duration: EDITOR_TRANSITION.toggle,
+                          bounce: 0.15,
+                        }
+                  }
+                />
+              )}
+              <span
+                className={cn(
+                  "relative z-10 flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors",
+                  active
+                    ? "text-background"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                <Icon className="h-3.5 w-3.5" />
+                {label}
+              </span>
+            </button>
+          );
+        })}
       </div>
-    </div>
+    </LayoutGroup>
   );
 });

--- a/components/editor/hooks/useEditorDocument.ts
+++ b/components/editor/hooks/useEditorDocument.ts
@@ -67,9 +67,8 @@ export function useEditorDocument(assets: EditorAssetSummary[]) {
   }, [assets, scratchAssets]);
 
   const effectiveSelectedAssetId = useMemo(() => {
-    if (selectedAssetId && assetMap.has(selectedAssetId)) {
-      return selectedAssetId;
-    }
+    if (selectedAssetId === null) return null;
+    if (assetMap.has(selectedAssetId)) return selectedAssetId;
     return assets[0]?.id ?? null;
   }, [assetMap, assets, selectedAssetId]);
 
@@ -195,7 +194,16 @@ export function useEditorDocument(assets: EditorAssetSummary[]) {
   );
 
   useEffect(() => {
-    if (!hasHydrated || !effectiveSelectedAssetId) return;
+    if (!hasHydrated) return;
+
+    if (!effectiveSelectedAssetId) {
+      if (documentRef.current === null) return;
+      flushPersistence();
+      documentRef.current = null;
+      setDocument(null);
+      setSelectedPathId(null);
+      return;
+    }
 
     const nextDocument =
       persistedDocument ??
@@ -213,6 +221,7 @@ export function useEditorDocument(assets: EditorAssetSummary[]) {
   }, [
     assetMap,
     effectiveSelectedAssetId,
+    flushPersistence,
     hasHydrated,
     loadDocument,
     persistedDocument,
@@ -521,13 +530,13 @@ export function useEditorDocument(assets: EditorAssetSummary[]) {
 
   const removeAssetFromTray = useCallback(
     (assetId: string) => {
-      removeFromTrayInStore(assetId, assets[0]?.id ?? null);
+      removeFromTrayInStore(assetId, null);
       if (assetId.startsWith("scratch-")) {
         removeScratchAsset(assetId);
         removeDocument(assetId);
       }
     },
-    [assets, removeDocument, removeScratchAsset],
+    [removeDocument, removeScratchAsset],
   );
 
   const isModified = useMemo(() => {

--- a/components/editor/panel/EditorWorkspacePanel.tsx
+++ b/components/editor/panel/EditorWorkspacePanel.tsx
@@ -1,13 +1,16 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Save } from "lucide-react";
-import { toast } from "sonner";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { SvgDefinitions } from "@/components/icon-page/panels/workspace/components/SvgDefinitions";
 import { WorkspaceGround } from "@/components/icon-page/panels/workspace/components/WorkspaceGround";
-import { WorkspaceActionBar } from "@/components/icon-page/panels/workspace/components/WorkspaceActionBar";
+import {
+  EditorActionBar,
+  EDITOR_TRANSITION,
+} from "@/components/editor/controls/EditorActionBar";
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
-import type { CustomizationState, IconData } from "@/lib/types";
+import type { CustomizationState } from "@/lib/types";
 import type {
   EditorAssetSummary,
   EditorDocument,
@@ -16,12 +19,10 @@ import { createEditorSvgMarkup, cloneDocument } from "@/lib/editor/svg";
 import { cn } from "@/lib/utils";
 import { EditorPathCanvas } from "@/components/editor/canvas/EditorPathCanvas";
 import { EditorDrawCanvas } from "@/components/editor/canvas/EditorDrawCanvas";
+import { EditorCanvasStage } from "@/components/editor/canvas/EditorCanvasStage";
 import { EditorMiniPreview } from "@/components/editor/preview/EditorMiniPreview";
 import { EditorModeToggle } from "@/components/editor/controls/EditorModeToggle";
-import {
-  EditorDrawToolbar,
-  type DrawTool,
-} from "@/components/editor/controls/EditorDrawToolbar";
+import { type DrawTool } from "@/components/editor/controls/EditorDrawToolbar";
 import { EditorIconTray } from "@/components/editor/controls/EditorIconTray";
 import { EditorSaveDialog } from "@/components/editor/dialogs/EditorSaveDialog";
 
@@ -80,24 +81,11 @@ export function EditorWorkspacePanel({
   const [editorMode, setEditorMode] = useState<EditorMode>("edit");
   const [activeTool, setActiveTool] = useState<DrawTool>("pen");
   const [showReference, setShowReference] = useState(false);
-
-  const isScratchAsset = !!editorDocument?.assetId.startsWith("scratch-");
+  const reduceMotion = useReducedMotion();
 
   const handleModeChange = (next: EditorMode) => {
-    if (next === "draw" && !isScratchAsset) {
-      toast.info(
-        "Click the + button in the icon tray to create a blank icon, then draw on it.",
-      );
-      return;
-    }
     setEditorMode(next);
   };
-
-  useEffect(() => {
-    if (editorMode === "draw" && !isScratchAsset) {
-      setEditorMode("edit");
-    }
-  }, [editorMode, isScratchAsset]);
 
   const [referencePathIds, setReferencePathIds] = useState<Set<string>>(
     () => new Set(),
@@ -122,7 +110,6 @@ export function EditorWorkspacePanel({
   const handleCreateBlank = onCreateBlankIcon
     ? () => {
         onCreateBlankIcon();
-        setEditorMode("draw");
       }
     : undefined;
 
@@ -192,57 +179,84 @@ export function EditorWorkspacePanel({
     return next;
   }, [previewDocument, editorDocument, editorMode, referencePathIds]);
 
-  const iconShim = useMemo<IconData | null>(() => {
-    if (!exportDocument) return null;
-    return {
-      id: exportDocument.assetId,
-      name: exportDocument.name ?? "runeicons-editor",
-      category: "all",
-      tags: [],
-    };
-  }, [exportDocument]);
-
   const getEditorSvgContent = async (): Promise<string> => {
     if (!exportDocument) return "";
     return createEditorSvgMarkup(exportDocument, state);
   };
 
-  const editorCanvas =
-    editorMode === "draw" ? (
-      <EditorDrawCanvas
-        document={editorDocument}
-        state={state}
-        viewBox={editorDocument?.viewBox ?? "0 0 24 24"}
-        onAddPath={onAddPath}
-        onErasePath={onErasePath}
-        activeTool={activeTool}
-        showReference={showReference}
-        referencePathIds={referencePathIds}
-      />
-    ) : (
-      <EditorPathCanvas
-        state={state}
-        path={selectedPath}
-        allPaths={editorDocument?.paths}
-        viewBox={editorDocument?.viewBox ?? "0 0 24 24"}
-        onSelectPath={onSelectPath}
-        onPreviewChange={(nextPath) => {
-          if (selectedPathId && editorDocument) {
-            setPreviewPathDraft({
-              assetId: editorDocument.assetId,
-              pathId: selectedPathId,
-              d: nextPath,
-            });
-          }
-        }}
-        onCommitChange={(nextPath) => {
-          if (selectedPathId) {
-            setPreviewPathDraft(null);
-            onCommitPathDraft(selectedPathId, nextPath);
-          }
-        }}
-      />
-    );
+  const isTrayEmpty = trayAssets.length === 0;
+
+  const editorCanvas = isTrayEmpty ? (
+    <div className="absolute inset-0 flex items-center justify-center p-8 text-center">
+      <p className="text-sm text-muted-foreground max-w-xs">
+        Add icons from the sidebar to start editing.
+      </p>
+    </div>
+  ) : (
+    <AnimatePresence mode="wait" initial={false}>
+      <motion.div
+        key={editorMode}
+        className="absolute inset-0"
+        initial={reduceMotion ? false : { opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={
+          reduceMotion
+            ? { opacity: 0, transition: { duration: 0 } }
+            : {
+                opacity: 0,
+                transition: {
+                  duration: EDITOR_TRANSITION.canvasFadeExit,
+                  ease: EDITOR_TRANSITION.easeOut,
+                },
+              }
+        }
+        transition={
+          reduceMotion
+            ? { duration: 0 }
+            : {
+                duration: EDITOR_TRANSITION.canvasFade,
+                ease: EDITOR_TRANSITION.easeOut,
+              }
+        }
+      >
+        {editorMode === "draw" ? (
+          <EditorDrawCanvas
+            document={editorDocument}
+            state={state}
+            viewBox={editorDocument?.viewBox ?? "0 0 24 24"}
+            onAddPath={onAddPath}
+            onErasePath={onErasePath}
+            activeTool={activeTool}
+            showReference={showReference}
+            referencePathIds={referencePathIds}
+          />
+        ) : (
+          <EditorPathCanvas
+            state={state}
+            path={selectedPath}
+            allPaths={editorDocument?.paths}
+            viewBox={editorDocument?.viewBox ?? "0 0 24 24"}
+            onSelectPath={onSelectPath}
+            onPreviewChange={(nextPath) => {
+              if (selectedPathId && editorDocument) {
+                setPreviewPathDraft({
+                  assetId: editorDocument.assetId,
+                  pathId: selectedPathId,
+                  d: nextPath,
+                });
+              }
+            }}
+            onCommitChange={(nextPath) => {
+              if (selectedPathId) {
+                setPreviewPathDraft(null);
+                onCommitPathDraft(selectedPathId, nextPath);
+              }
+            }}
+          />
+        )}
+      </motion.div>
+    </AnimatePresence>
+  );
 
   return (
     <>
@@ -274,11 +288,23 @@ export function EditorWorkspacePanel({
                 </div>
               </foreignObject>
 
-              <foreignObject
+              <motion.foreignObject
                 x={250}
                 y={150}
                 width={600}
-                height={editorMode === "draw" ? 600 : 500}
+                initial={false}
+                animate={{ height: editorMode === "draw" ? 600 : 500 }}
+                transition={
+                  reduceMotion
+                    ? { duration: 0 }
+                    : {
+                        duration:
+                          editorMode === "draw"
+                            ? EDITOR_TRANSITION.canvas
+                            : EDITOR_TRANSITION.canvasExit,
+                        ease: EDITOR_TRANSITION.easeInOut,
+                      }
+                }
               >
                 <div className="w-full h-full pointer-events-auto relative">
                   <div className="pointer-events-none absolute inset-0 border border-white/15 bg-white/2.5" />
@@ -299,26 +325,59 @@ export function EditorWorkspacePanel({
                         : undefined
                     }
                   >
-                    <div className="absolute inset-0 z-10">
+                    <EditorCanvasStage
+                      state={state}
+                      className="absolute inset-0 z-10"
+                    >
                       {editorCanvas}
-                    </div>
+                    </EditorCanvasStage>
                   </div>
                 </div>
-              </foreignObject>
+              </motion.foreignObject>
 
-              {editorMode === "edit" ? (
-                <foreignObject x={250} y={650} width={600} height={100}>
-                  <div className="w-full h-full pointer-events-auto">
-                    <EditorIconTray
-                      assets={trayAssets}
-                      selectedAssetId={selectedAssetId}
-                      onAssetSelect={(asset) => onSelectAssetById(asset.id)}
-                      onRemoveAsset={onRemoveAssetFromTray}
-                      onCreateBlank={handleCreateBlank}
-                    />
-                  </div>
-                </foreignObject>
-              ) : null}
+              <AnimatePresence initial={false}>
+                {editorMode === "edit" && (
+                  <motion.foreignObject
+                    key="icon-tray"
+                    x={250}
+                    y={650}
+                    width={600}
+                    height={100}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={
+                      reduceMotion
+                        ? { opacity: 0, transition: { duration: 0 } }
+                        : {
+                            opacity: 0,
+                            transition: {
+                              duration: EDITOR_TRANSITION.tray * 0.7,
+                              ease: EDITOR_TRANSITION.easeOut,
+                            },
+                          }
+                    }
+                    transition={
+                      reduceMotion
+                        ? { duration: 0 }
+                        : {
+                            duration: EDITOR_TRANSITION.tray,
+                            ease: EDITOR_TRANSITION.easeOut,
+                            delay: EDITOR_TRANSITION.trayDelay,
+                          }
+                    }
+                  >
+                    <div className="w-full h-full pointer-events-auto">
+                      <EditorIconTray
+                        assets={trayAssets}
+                        selectedAssetId={selectedAssetId}
+                        onAssetSelect={(asset) => onSelectAssetById(asset.id)}
+                        onRemoveAsset={onRemoveAssetFromTray}
+                        onCreateBlank={handleCreateBlank}
+                      />
+                    </div>
+                  </motion.foreignObject>
+                )}
+              </AnimatePresence>
             </svg>
           </div>
         </div>
@@ -330,19 +389,8 @@ export function EditorWorkspacePanel({
           />
         </div>
 
-        {editorMode === "draw" ? (
-          <div className="absolute top-1/2 left-3 -translate-y-1/2 z-30">
-            <EditorDrawToolbar
-              activeTool={activeTool}
-              onToolChange={setActiveTool}
-              showReference={showReference}
-              onToggleReference={() => setShowReference((v) => !v)}
-            />
-          </div>
-        ) : null}
-
         <div className="absolute bottom-9.5 left-1/2 -translate-x-1/2 z-10">
-          <WorkspaceActionBar
+          <EditorActionBar
             state={state}
             onChange={onGlobalStateChange}
             onUndo={onUndo}
@@ -352,9 +400,12 @@ export function EditorWorkspacePanel({
             onReset={onResetAsset}
             showGrid={showGrid}
             onGridToggle={() => setShowGrid((prev) => !prev)}
-            selectedIcon={iconShim}
             onGetSvgContent={getEditorSvgContent}
-            hideAdvancedExports
+            editorMode={editorMode}
+            activeTool={activeTool}
+            onToolChange={setActiveTool}
+            showReference={showReference}
+            onToggleReference={() => setShowReference((v) => !v)}
             additionalDropdownItems={
               <DropdownMenuItem
                 className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-[11px] font-medium transition-colors focus:bg-white/10 focus:text-white"

--- a/components/editor/preview/EditorMiniPreview.tsx
+++ b/components/editor/preview/EditorMiniPreview.tsx
@@ -4,6 +4,7 @@ import { memo } from "react";
 import type { CustomizationState } from "@/lib/types";
 import type { EditorDocument } from "@/lib/editor/types";
 import { EditorSvgPreview } from "@/components/editor/preview/EditorSvgPreview";
+import { EditorCanvasStage } from "@/components/editor/canvas/EditorCanvasStage";
 
 interface EditorMiniPreviewProps {
   document: EditorDocument | null;
@@ -20,12 +21,14 @@ export const EditorMiniPreview = memo(function EditorMiniPreview({
 
   return (
     <div className="w-full h-full bg-background border border-border shadow-md flex items-center justify-center p-[12%] pointer-events-auto">
-      <EditorSvgPreview
-        document={document}
-        state={state}
-        className="w-full h-full"
-        onPathClick={onPathClick}
-      />
+      <EditorCanvasStage state={state} applyContainerBox={false}>
+        <EditorSvgPreview
+          document={document}
+          state={state}
+          className="w-full h-full"
+          onPathClick={onPathClick}
+        />
+      </EditorCanvasStage>
     </div>
   );
 });

--- a/components/editor/preview/EditorSvgPreview.tsx
+++ b/components/editor/preview/EditorSvgPreview.tsx
@@ -4,7 +4,7 @@ import { memo, useRef, useEffect } from "react";
 import type { EditorDocument } from "@/lib/editor/types";
 import type { CustomizationState } from "@/lib/types";
 import { cn } from "@/lib/utils";
-import { resolveEditorPathPaint } from "@/lib/editor/svg";
+import { resolveEditorPathStyle } from "@/lib/editor/svg";
 
 function stripDefsWrapper(defs?: string) {
   if (!defs) {
@@ -55,16 +55,16 @@ export const EditorSvgPreview = memo(function EditorSvgPreview({
       {document.paths
         .filter((path) => path.visible)
         .map((path) => {
-          const paint = resolveEditorPathPaint(path, state);
+          const style = resolveEditorPathStyle(path, state);
           return (
             <path
               key={path.id}
               d={path.d}
-              fill={paint.fill ?? "none"}
-              stroke={paint.stroke ?? "none"}
-              strokeWidth={path.strokeWidth ?? 1.5}
-              strokeLinecap={path.strokeLinecap}
-              strokeLinejoin={path.strokeLinejoin}
+              fill={style.fill}
+              stroke={style.stroke}
+              strokeWidth={style.strokeWidth}
+              strokeLinecap={style.strokeLinecap}
+              strokeLinejoin={style.strokeLinejoin}
               opacity={path.opacity}
               fillOpacity={path.fillOpacity}
               strokeOpacity={path.strokeOpacity}

--- a/components/landing/svg/hero/defs.tsx
+++ b/components/landing/svg/hero/defs.tsx
@@ -20,8 +20,8 @@ const HeroDefs = () => (
       height="8"
       patternTransform="rotate(45)"
     >
-      <rect width="8" height="8" fill="#FBBF24" />
-      <rect width="4" height="8" fill="#000000" />
+      <rect width="8" height="8" className="hazardStripeYellow" />
+      <rect width="4" height="8" className="hazardStripeDark" />
     </pattern>
     <filter
       id="cloudBlur"

--- a/lib/editor/svg.ts
+++ b/lib/editor/svg.ts
@@ -14,6 +14,7 @@ const KNOWN_VARIANTS: readonly EditorVariant[] = [
   "pixelated",
 ];
 import type { CustomizationState } from "@/lib/types";
+import { STROKE_STYLE_MAP, type StrokeStyle } from "@/lib/stroke-style";
 import { normalizeEditorPathData } from "./path-data";
 
 type StackEntry = {
@@ -424,10 +425,30 @@ export function resolveEditorPathPaint(
   state?: CustomizationState,
 ) {
   if (state?.iconGradient) {
+    const target = state.gradient.target ?? "both";
+    const gradientPaint = "url(#icon-gradient)";
+    const applyToStroke = target === "stroke" || target === "both";
+    const applyToFill = target === "fill" || target === "both";
+
+    const stateColor = state.colors[0];
+    const fallbackPaint =
+      stateColor && !isDefaultEditorPaint(stateColor)
+        ? stateColor
+        : "currentColor";
+
     return {
       stroke:
-        path.stroke && path.stroke !== "none" ? "url(#icon-gradient)" : path.stroke,
-      fill: path.fill && path.fill !== "none" ? "url(#icon-gradient)" : path.fill,
+        path.stroke && path.stroke !== "none"
+          ? applyToStroke
+            ? gradientPaint
+            : fallbackPaint
+          : path.stroke ?? "none",
+      fill:
+        path.fill && path.fill !== "none"
+          ? applyToFill
+            ? gradientPaint
+            : fallbackPaint
+          : path.fill ?? "none",
     };
   }
 
@@ -444,6 +465,41 @@ export function resolveEditorPathPaint(
       path.fill && path.fill !== "none" && isDefaultEditorPaint(path.fill)
         ? defaultPaint
         : path.fill ?? "none",
+  };
+}
+
+export interface EditorPathStyle {
+  fill: string;
+  stroke: string;
+  strokeWidth: number;
+  strokeLinecap: "round" | "butt" | "square";
+  strokeLinejoin: "round" | "miter" | "bevel";
+}
+
+export function resolveEditorPathStyle(
+  path: Pick<
+    EditorIconPath,
+    "stroke" | "fill" | "strokeWidth" | "strokeLinecap" | "strokeLinejoin"
+  >,
+  state?: CustomizationState,
+): EditorPathStyle {
+  const paint = resolveEditorPathPaint(path, state);
+  const styleKey = (state?.strokeStyle ?? "round") as StrokeStyle;
+  const styleDefaults = STROKE_STYLE_MAP[styleKey] ?? STROKE_STYLE_MAP.round;
+  const stateDrivenStyle = Boolean(state?.strokeStyle);
+
+  return {
+    fill: paint.fill ?? "none",
+    stroke: paint.stroke ?? "none",
+    strokeWidth: stateDrivenStyle
+      ? styleDefaults.strokeWidth
+      : path.strokeWidth ?? styleDefaults.strokeWidth,
+    strokeLinecap: stateDrivenStyle
+      ? styleDefaults.strokeLinecap
+      : path.strokeLinecap ?? styleDefaults.strokeLinecap,
+    strokeLinejoin: stateDrivenStyle
+      ? styleDefaults.strokeLinejoin
+      : path.strokeLinejoin ?? styleDefaults.strokeLinejoin,
   };
 }
 

--- a/lib/icons/index.ts
+++ b/lib/icons/index.ts
@@ -33,8 +33,6 @@ export function resolveLibraryIconType(state: StateIconType): IconType {
 
 export const EDITOR_SUPPORTED_TYPES = [
   "normal",
-  "duotone",
-  "fill",
   "pixelated",
 ] as const;
 


### PR DESCRIPTION
Editor sidebar controls (scale, color, stroke, gradient, blur, noise) now flow through every canvas surface via EditorCanvasStage and resolveEditorPathStyle. Draw tools consolidate into a single layout-coordinated EditorActionBar with spring transitions between Edit and Draw modes. Emptying the icon tray clears selection across canvas, mini-preview, and sidebar instead of falling back to a default icon.